### PR TITLE
rule: no-conditional-literals-in-jsx

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
 
 const allRules = {
   'strict-mui-imports': require('./lib/rules/strict-mui-imports'),
+  'no-conditional-literals-in-jsx': require('./lib/rules/no-conditional-literals-in-jsx'),
   'no-unwrapped-jsx-text': require('./lib/rules/no-unwrapped-jsx-text'),
   'polyfill-resize-observer': require('./lib/rules/polyfill-resize-observer')
 }
@@ -21,6 +22,7 @@ const rulesConfig = {
   },
   rules: {
     '@sayari/strict-mui-imports': 2,
+    '@sayari/no-conditional-literals-in-jsx': 2,
     '@sayari/no-unwrapped-jsx-text': 2,
     '@sayari/polyfill-resize-observer': 2,
   }
@@ -37,4 +39,3 @@ module.exports = {
     all: rulesConfig
   }
 }
-

--- a/lib/rules/no-conditional-literals-in-jsx.js
+++ b/lib/rules/no-conditional-literals-in-jsx.js
@@ -1,0 +1,56 @@
+'use strict'
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Browser auto-translation will break if pieces of text nodes are be rendered conditionally.'
+    },
+    schema: [],
+    messages: {
+      unexpected:
+        'Conditional expression is a sibling of raw text and must be wrapped in <div> or <span>'
+    }
+  },
+  create: function (context) {
+    return {
+      // Imagine evaluating <div>text {conditional && 'string'}</div>
+      JSXExpressionContainer(node) {
+        // We start at the expression {conditional && 'string'}
+        if (node.expression.type !== 'LogicalExpression') return
+
+        // "text" is one of the siblingTextNodes.
+        const siblingTextNodes = (node.parent.children || []).filter((n) => {
+          // In normal code these are 'Literal', but in test code they are 'JSXText'
+          const isText = n.type === 'Literal' || n.type === 'JSXText'
+          // Skip empty text nodes, like "   \n   " -- these may be JSX artifacts
+          return isText && !!n.value.trim()
+        })
+
+        // If we were evaluting
+        //   <div>{property} {conditional && 'string'}</div>
+        // Then {property} would be one of the siblingExpressionNodes
+        const siblingExpressionNodes = (node.parent.children || []).filter(
+          (n) =>
+            n.type === 'JSXExpressionContainer' &&
+            (n.expression.type === 'Identifier' ||
+              n.expression.type === 'MemberExpression')
+        )
+
+        // Operands of {conditional && 'string'} -- the conditional and the
+        // literal. We want to make sure we have a text literal, otherwise we'd
+        // trigger this rule on the (safe) {conditional && <div>string</div>}.
+        const expressionOperandTypes = [
+          node.expression.left.type,
+          node.expression.right.type
+        ]
+        if (
+          siblingTextNodes.concat(siblingExpressionNodes).length > 0 &&
+          expressionOperandTypes.includes('Literal')
+        ) {
+          context.report({ node, messageId: 'unexpected' })
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I was encountering crashes caused by Google Translate running on a React app. The rule `no-unwrapped-jsx-text` helped find some cases that were triggering crashes but not all of them. Someone else [posted a gist](https://gist.github.com/azirbel/51518d919de979197a7c5c25c54a56d6) with another rule `no-conditional-literals-in-jsx` to find more cases. I thought because this repo exists it would be useful if `no-conditional-literals-in-jsx` were also included to be thorough and convenient. I'm not completely sure how to give attribution to the creator of the gist; I take no credit for the work.

