### PR TITLE
Simplify check siblings.every

### DIFF
--- a/lib/rules/no-unwrapped-jsx-text.js
+++ b/lib/rules/no-unwrapped-jsx-text.js
@@ -86,7 +86,7 @@ module.exports = {
       const { range, parent } = element
 
       const siblings = filterSiblings(range, parent.children)
-      if (siblings.length === 0 || siblings.every(({ type }) => type === JSX_TEXT)) {
+      if (siblings.every(({ type }) => type === JSX_TEXT)) {
         return null
       }
 


### PR DESCRIPTION
I just omitted check for `length === 0`. It is not required, because any `every()` returns true with empty array.
```js
[].every(() => false);// true
```